### PR TITLE
Fix #6 Now you can also return value from define function like can be done with require.js

### DIFF
--- a/lib/RequireContext.js
+++ b/lib/RequireContext.js
@@ -251,10 +251,16 @@ RequireContext.prototype.theDefine = function theDefine(dependencies, fn, arg3) 
 			parent.exports = fn;
 	} else {
 		fn = dependencies;
-		if(typeof fn == "function")
-			fn(reqFn, parent.exports, parent);
-		else
+		if(typeof fn == "function"){
+			var fnReturnExports = fn(reqFn, parent.exports, parent);
+			// If nothing has been added to the parent.exports then replace with the
+			// return value of the function.
+			if(Object.keys(parent.exports).length === 0){
+				parent.exports = fnReturnExports;
+			}
+		}else{
 			parent.exports = fn;
+		}
 	}
 }
 

--- a/lib/RequireContext.js
+++ b/lib/RequireContext.js
@@ -252,13 +252,11 @@ RequireContext.prototype.theDefine = function theDefine(dependencies, fn, arg3) 
 	} else {
 		fn = dependencies;
 		if(typeof fn == "function"){
-			var fnReturnExports = fn(reqFn, parent.exports, parent);
-			// If nothing has been added to the parent.exports then replace with the
-			// return value of the function.
-			if(Object.keys(parent.exports).length === 0){
-                // You can return 0, false and other falsy values.
-                parent.exports = fnReturnExports === void 0 ? {} : fnReturnExports;
-			}
+            var orignalExports = parent.exports;
+            var fnReturnExports = fn(reqFn, parent.exports, parent);
+            if(orignalExports === parent.exports && Object.keys(orignalExports).length === 0 && fnReturnExports !== undefined) {
+              parent.exports = fnReturnExports;
+            }
 		}else{
 			parent.exports = fn;
 		}

--- a/lib/RequireContext.js
+++ b/lib/RequireContext.js
@@ -256,7 +256,8 @@ RequireContext.prototype.theDefine = function theDefine(dependencies, fn, arg3) 
 			// If nothing has been added to the parent.exports then replace with the
 			// return value of the function.
 			if(Object.keys(parent.exports).length === 0){
-				parent.exports = fnReturnExports;
+                // You can return 0, false and other falsy values.
+                parent.exports = fnReturnExports === void 0 ? {} : fnReturnExports;
 			}
 		}else{
 			parent.exports = fn;

--- a/test/commonjs.js
+++ b/test/commonjs.js
@@ -77,4 +77,16 @@ describe("commonjs", function() {
 		fs.should.be.equal(require("fs"));
 	});
 
+    it("should define a module by returning a value from a define wrapper", function(done) {
+        var data = req('./fixtures/commonjs/wrappedReturn');
+        data.a.should.be.equal(1);
+        done();
+    });
+
+    it("should give priority to 'module.exports' or 'exports' instead of the value returned", function(done) {
+        var data = req('./fixtures/commonjs/wrappedReturnAndSetExports');
+        data.a.should.be.equal(1);
+        done();
+    });
+
 });

--- a/test/commonjs.js
+++ b/test/commonjs.js
@@ -89,4 +89,17 @@ describe("commonjs", function() {
         done();
     });
 
+    it("should return an empty object if nothing is returned or set on 'module.exports' or 'exports'", function(done) {
+        var data = req('./fixtures/commonjs/wrappedEmpty');
+        data.should.be.a("object");
+        done();
+    });
+
+    it("should be able to return a falsy value", function(done) {
+        var data = req('./fixtures/commonjs/wrappedFalsy');
+        data.should.be.equal(false);
+        done();
+    });
+
+
 });

--- a/test/commonjs.js
+++ b/test/commonjs.js
@@ -101,5 +101,19 @@ describe("commonjs", function() {
         done();
     });
 
+    it("should return an empty object when returns undefined", function(done) {
+        var data = req('./fixtures/commonjs/wrappedModuleExportsUndefined');
+        should.not.exist(data);
+        done();
+    });
+
+    it("should define a module with exports when wrapped", function(done) {
+        var data = req('./fixtures/commonjs/wrappedModuleExportsValue');
+        data.test.should.be.equal(1);
+        done();
+    });
+
+
+
 
 });

--- a/test/fixtures/commonjs/wrappedEmpty.js
+++ b/test/fixtures/commonjs/wrappedEmpty.js
@@ -1,0 +1,2 @@
+define(function(require, exports, module){
+});

--- a/test/fixtures/commonjs/wrappedFalsy.js
+++ b/test/fixtures/commonjs/wrappedFalsy.js
@@ -1,0 +1,3 @@
+define(function(require, exports, module){
+    return false;
+});

--- a/test/fixtures/commonjs/wrappedModuleExportsUndefined.js
+++ b/test/fixtures/commonjs/wrappedModuleExportsUndefined.js
@@ -1,0 +1,3 @@
+define(function(require, exports, module) {
+  module.exports = undefined;
+});

--- a/test/fixtures/commonjs/wrappedModuleExportsValue.js
+++ b/test/fixtures/commonjs/wrappedModuleExportsValue.js
@@ -1,0 +1,3 @@
+define(function(require, exports, module) {
+  module.exports = {test: 1}
+});

--- a/test/fixtures/commonjs/wrappedReturn.js
+++ b/test/fixtures/commonjs/wrappedReturn.js
@@ -1,0 +1,5 @@
+define(function(require, exports, module){
+    return {
+        a: 1
+    }
+});

--- a/test/fixtures/commonjs/wrappedReturnAndSetExports.js
+++ b/test/fixtures/commonjs/wrappedReturnAndSetExports.js
@@ -1,0 +1,6 @@
+define(function(require, exports, module){
+    exports.a = 1;
+    return {
+        a: 2
+    }
+});

--- a/test/fixtures/hot/counter-value.js
+++ b/test/fixtures/hot/counter-value.js
@@ -1,0 +1,1 @@
+module.exports = 3


### PR DESCRIPTION
For example

```
define(function(require, exports, module){

    var logic = {
        a: 3
    }
    return logic;
});
```

will now work.

But this will continue to work too

```
define(function(require, exports, module){

    var logic = {
        a: 3
    }
    exports.a= logic.a;
});
```
